### PR TITLE
add subcommand to simulate reads based on a config

### DIFF
--- a/SDRranger/config.py
+++ b/SDRranger/config.py
@@ -4,11 +4,14 @@ import json
 
 from .misc import gzip_friendly_open
 
+class CommandLineArguments:
+    def __new__(cls, arguments):
+        if "simulate_reads" in arguments:
+            return SimulationCommandLineArguments(arguments)
+        else:
+            return AnalysisCommandLineArguments(arguments)
 
-class CommandLineArguments(object):
-    """
-    Wraps the raw arguments provided by docopt.
-    """
+class CommandLineArgumentsBase:
     def __init__(self, arguments):
         self._arguments = arguments
 
@@ -26,17 +29,12 @@ class CommandLineArguments(object):
     @property
     def command(self):
         # We have to do this weird loop to deal with the way docopt stores the command name
-        for possible_command in ('count_gDNA', 'count_RNA', 'count_matrix'):
+        for possible_command in ('count_gDNA', 'count_RNA', 'count_matrix', 'simulate_reads'):
             if self._arguments.get(possible_command):
                 return possible_command
-
     @property
-    def fastq_dir(self):
-        return self._arguments['<fastq_dir>']
-
-    @property
-    def SDR_bam_file(self):
-        return self._arguments['<SDR_bam_file>']
+    def config(self):
+        return self._config
 
     @property
     def log_level(self):
@@ -47,6 +45,21 @@ class CommandLineArguments(object):
         # default to silent if the user supplies no verbosity setting
         return log_level.get(self._arguments['-v'], logging.ERROR)
 
+class AnalysisCommandLineArguments(CommandLineArgumentsBase):
+    """
+    Wraps the raw arguments provided by docopt.
+    """
+    def __init__(self, arguments):
+        super().__init__(arguments)
+
+    @property
+    def fastq_dir(self):
+        return self._arguments['<fastq_dir>']
+
+    @property
+    def SDR_bam_file(self):
+        return self._arguments['<SDR_bam_file>']
+
     @property
     def star_ref_dir(self):
         return self._arguments['--STAR-ref-dir']
@@ -56,13 +69,41 @@ class CommandLineArguments(object):
         return self._arguments['--STAR-output']
 
     @property
-    def config(self):
-        return self._config
-
-    @property
     def threads(self):
         return int(self._arguments['--threads'])
 
     @property
     def output_dir(self):
         return self._arguments['--output-dir']
+
+class SimulationCommandLineArguments(CommandLineArgumentsBase):
+    def __init__(self, arguments):
+        super().__init__(arguments)
+
+    @property
+    def fastq_prefix(self):
+        return self._arguments['--fastq-prefix']
+
+    @property
+    def nreads(self):
+        return int(self._arguments['--nreads'])
+
+    @property
+    def unique_umis(self):
+        return float(self._arguments['--unique-umis'])
+
+    @property
+    def seed(self):
+        return int(self._arguments['--seed'])
+
+    @property
+    def error_probability(self):
+        return float(self._arguments['--error-probability'])
+
+    @property
+    def substitution_probability(self):
+        return float(self._arguments['--substitution-probability'])
+
+    @property
+    def insertion_probability(self):
+        return float(self._arguments['--insertion-probability'])

--- a/SDRranger/main.py
+++ b/SDRranger/main.py
@@ -5,23 +5,32 @@ Usage:
   SDRranger count_RNA        <fastq_dir> (--STAR-ref-dir=<> | --STAR-output=<>...) --config=<> [--output-dir=<>] [--threads=<>] [-v | -vv | -vvv]
   SDRranger count_gDNA       <fastq_dir> --STAR-ref-dir=<> --config=<> [--output-dir=<>] [--threads=<>] [-v | -vv | -vvv]
   SDRranger count_matrix       <SDR_bam_file> --output-dir=<> [--threads=<>] [-v | -vv | -vvv]
+  SDRranger simulate_reads   --config=<> --fastq-prefix=<> --nreads=<> [--unique-umis=<>] [--seed=<>] [--error-probability=<>] [--substitution-probability=<>] [--insertion-probability=<>] [-v | -vv | -vvv]
 
 Options:
-  --STAR-ref-dir=<>: Path to directory with STAR index.
-  --STAR-output=<>: Path to STAR output file (BAM/SAM). Can be repeated multiple times,
-                    in which case the order must correspond to the lexicographic ordering
-                    of paired FASTQ files in <fastq_dir>.
-  --config=<>: Path to JSON configuration.
-  --output-dir=<>: Path to output directory [default: .].
-  --threads=<>: Number of threads [default: 1].
-  -v: Verbose output.
-  -h --help     Show this screen.
-  --version     Show version.
+  --STAR-ref-dir=<>:              Path to directory with STAR index.
+  --STAR-output=<>:               Path to STAR output file (BAM/SAM). Can be repeated multiple times,
+                                    in which case the order must correspond to the lexicographic ordering
+                                    of paired FASTQ files in <fastq_dir>.
+  --config=<>:                    Path to JSON configuration.
+  --output-dir=<>:                Path to output directory [default: .].
+  --threads=<>:                   Number of threads [default: 1].
+  -v:                             Verbose output.
+  --fastq-prefix=<>:              Prefix for output FASTQ files.
+  --nreads=<>:                    Number of reads to simulate.
+  --unique-umis=<>:               Fraction of all reads that have unique UMIs [default: 0.5].
+  --seed=<>:                      Random seed [default: 42].
+  --error-probability=<>:         Probability of an error occurring [default: 0.1]. Set to a negative number to
+                                    always introduce as many errors as allowed by the configuration.
+  --substitution-probability=<>:  Probability of generating a substitution as opposed to an indel [default: 0.7].
+  --insertion-probability=<>:     Probability of generating an insertion as opposed to a deletion when generating an indel [default: 0.5].
+  -h --help                       Show this screen.
+  --version                       Show version.
 
 Commands:
-  count_gDNA    Process and count Genomic gDNA files
-  count_RNA     Process and count Transcriptomic RNA files
-  count_matrix  Build a count matrix (or matrices) from an existing bam file
+  count_gDNA                      Process and count Genomic gDNA files
+  count_RNA                       Process and count Transcriptomic RNA files
+  count_matrix                    Build a count matrix (or matrices) from an existing bam file
 """
 import logging
 import os
@@ -31,6 +40,7 @@ from .config import CommandLineArguments
 from .RNAcount import process_RNA_fastqs
 from .gDNAcount import process_gDNA_fastqs 
 from .count_matrix import build_count_matrices_from_bam
+from .simulate import simulate_reads
 
 def main(**kwargs):
     docopt_args = docopt(__doc__, version=__version__)
@@ -48,6 +58,7 @@ def main(**kwargs):
         'count_RNA': process_RNA_fastqs,
         'count_gDNA': process_gDNA_fastqs,
         'count_matrix': build_count_matrices_from_bam,
+        'simulate_reads': simulate_reads
     }
 
     commands[arguments.command](arguments)

--- a/SDRranger/simulate.py
+++ b/SDRranger/simulate.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+import sys
+import os
+import gzip
+from collections import defaultdict
+
+import numpy as np
+
+alphabet = ("A", "T", "G", "C")
+complement = {"A": "T", "T": "A", "G": "C", "C": "G"}
+
+alphabet_subsets = {"A": ("T", "G", "C"),
+                    "T": ("A", "G", "C"),
+                    "G": ("A", "T", "C"),
+                    "C": ("A", "T", "G")}
+
+def one_mutation(seq: str, position: int, substitutionprob: float, insertionprob: float, rng: np.random.Generator):
+    if rng.random() < substitutionprob:
+        seq = seq[:position] + rng.choice(alphabet_subsets[seq[position]]) + seq[position + 1:]
+    else:
+        if rng.random() < insertionprob:
+            seq = seq[:position] + rng.choice(alphabet) + seq[position:] # 1bp insertion
+        else:
+            seq = seq[:position] + seq[position + 1:] # 1bp deletion
+    return seq
+
+def mutate_read_probabilistic(seq: str, errorprob: float, substitutionprob: float, insertionprob: float, rng: np.random.Generator):
+    pos = 0
+    while pos < len(seq):
+        if rng.random() < errorprob:
+            seq = one_mutation(seq, pos, substitutionprob, insertionprob, rng)
+        pos += 1
+    return seq
+
+def mutate_read_maxerrors(seq: str, maxerrors: int, substitutionprob: float, insertionprob: float, rng: np.random.Generator):
+    positions = rng.choice(len(seq), size=maxerrors, replace=False)
+    for pos in positions:
+        seq = one_mutation(seq, pos, substitutionprob, insertionprob, rng)
+    return seq
+
+def make_read(blocks: dict, name_prefix: str, mutate_umi: bool, mutatereadfun, error_probability: float, substitution_probability, insertion_probability: float, umis: dict[list[str]], rng: np.random.Generator):
+    read = ""
+    readname = name_prefix
+
+    for blockidx, block in enumerate(blocks):
+        if block["blocktype"] == "randomBarcode":
+            if not mutate_umi:
+                blocksequence = "".join(rng.choice(alphabet, block["length"]))
+                blockname = blocksequence
+                umis[blockidx].append(blocksequence)
+            else:
+                blockname = rng.choice(umis[blockidx])
+                blocksequence = mutatereadfun(blockname, block["maxerrors"], error_probability, substitution_probability, insertion_probability, rng)
+        elif block["blocktype"] == "constantRegion" or block["blocktype"] == "barcodeList":
+            seqidx = rng.choice(len(block["sequence"]))
+            blockname = block["name"][seqidx] if "name" in block else block["sequence"][seqidx]
+            blocksequence = mutatereadfun(block["sequence"][seqidx], block["maxerrors"], error_probability, substitution_probability, insertion_probability, rng)
+        readname += f"_{blockname}"
+        read += blocksequence
+
+    nonbc_sequence = "".join(rng.choice(alphabet, rng.poisson(20)))
+    read += nonbc_sequence
+
+    return readname, read
+
+def simulate_reads(arguments):
+    rng = np.random.default_rng(arguments.seed)
+
+    if "barcode_struct_r2" in arguments.config:
+        fq1name = f"{arguments.fastq_prefix}_1.txt.gz"
+        fq2name = f"{arguments.fastq_prefix}_2.txt.gz"
+        fq2 = gzip.open(fq2name, "wt")
+    else:
+        fq1name = f"{arguments.fastq_prefix}.txt.gz"
+
+    os.makedirs(os.path.dirname(arguments.fastq_prefix), exist_ok=True)
+
+    fq1 = gzip.open(fq1name, "wt")
+
+    read1_umis = defaultdict(list)
+    read2_umis = defaultdict(list)
+
+    if arguments.error_probability <= 0:
+        mutatereadfun = lambda seq, maxerrors, errorprob, substitutionprob, insertionprob, rng: mutate_read_maxerrors(seq, maxerrors, substitutionprob, insertionprob, rng)
+    else:
+        mutatereadfun = lambda seq, maxerrors, errorprob, substitutionprob, insertionprob, rng: mutate_read_probabilistic(seq, errorprob, substitutionprob, insertionprob, rng)
+
+    for readidx in range(arguments.nreads):
+        read1name, read1 = make_read(arguments.config["barcode_struct_r1"]["blocks"], str(readidx), readidx > arguments.unique_umis * arguments.nreads,  mutatereadfun, arguments.error_probability, arguments.substitution_probability, arguments.insertion_probability, read1_umis, rng)
+        revcomp = False
+        if arguments.config["unknown_read_orientation"] and rng.random() > 0.5:
+            read1 = read1.translate(complement)[::-1]
+            revcomp = True
+        print(read1name, read1, "+", "E" * len(read1), sep="\n", file=fq1)
+
+        if "barcode_struct_r2" in arguments.config:
+            read2name, read2 = make_read(arguments.config["barcode_struct_r2"]["blocks"], str(readidx), readidx > arguments.unique_umis * arguments.nreads, mutatereadfun, arguments.error_probability, arguments.substitution_probability, arguments.insertion_probability, read1_umis, rng)
+            if revcomp:
+                read2 = read2.translate(complement)[::-1]
+            print(read2name, read2, "+", "E" * len(read2), sep="\n", file=fq2)
+
+    fq1.close()
+
+    if "barcode_struct_r2" in arguments.config:
+        fq2.close()


### PR DESCRIPTION
This has two modes: Probabilistic, which has a constant error probability for each base, and non-probabilistic, which inserts as many errors as are allowed by the configuration.