### PR TITLE
Parallel STAR

### DIFF
--- a/SDRranger/RNAcount.py
+++ b/SDRranger/RNAcount.py
@@ -78,7 +78,7 @@ def process_RNA_fastqs(arguments):
                 paired_fq_bam_fpaths.append((bc_fq_fpath, star_out_fpath))
         else:
             log.info(f'Using STAR results from {arguments.star_output_path}')
-            for fpaths, bampath in zip(paired_fpaths, arguments.star_output_path, strict=True):
+            for fpaths, bampath in zip(sorted(paired_fpaths, key=lambda x: x[bc_fq_idx]), arguments.star_output_path, strict=True):
                 paired_fq_bam_fpaths.append((fpaths[bc_fq_idx], bampath))
     
         log.info('Writing output to:')

--- a/SDRranger/RNAcount.py
+++ b/SDRranger/RNAcount.py
@@ -290,12 +290,10 @@ def process_chunk_of_reads(args_and_fpaths):
     with (pysam.AlignmentFile(tmp_out_bam_fpath, 'wb', template=pysam.AlignmentFile(sorted_bam_fpath)) as out,
           pysam.AlignmentFile(sorted_bam_fpath, 'rb') as rbam):
         for bc_rec in SeqIO.parse(misc.gzip_friendly_open(tmp_fq_fpath), 'fastq'):
-            p_read = misc.get_bam_read_by_name(bc_rec.id, rbam, sorted_bam_idx)
-            if not p_read:
-                continue
-            score, read = process_bc_rec_and_p_read(config, bc_rec, p_read, aligners, decoders)
-            if score >= thresh and read:
-                out.write(read)
+            for p_read in misc.get_bam_read_by_name(bc_rec.id, rbam, sorted_bam_idx):
+                score, read = process_bc_rec_and_p_read(config, bc_rec, p_read, aligners, decoders)
+                if score >= thresh and read:
+                    out.write(read)
     os.remove(tmp_fq_fpath)
     return tmp_out_bam_fpath
 

--- a/SDRranger/config.py
+++ b/SDRranger/config.py
@@ -26,7 +26,7 @@ class CommandLineArguments(object):
     @property
     def command(self):
         # We have to do this weird loop to deal with the way docopt stores the command name
-        for possible_command in ('count_gDNA', 'count_RNA', 'count_matrix'):
+        for possible_command in ('count_gDNA', 'preprocess_gDNA', 'count_RNA', 'count_matrix'):
             if self._arguments.get(possible_command):
                 return possible_command
 

--- a/SDRranger/gDNAcount.py
+++ b/SDRranger/gDNAcount.py
@@ -5,12 +5,14 @@ import pysam
 import itertools
 import tempfile
 import numpy as np
+import pickle
 import subprocess
 import shutil
 import scipy
 from . import misc
 from Bio import SeqIO
 from collections import defaultdict, Counter
+from glob import glob
 from multiprocessing import Pool
 from scipy.sparse import lil_matrix
 from .bc_decoders import BCDecoder, SBCDecoder
@@ -22,6 +24,64 @@ pysam.set_verbosity(0)
 
 n_first_seqs = 10000  # n seqs for finding score threshold
 
+def preprocess_gDNA_fastqs(arguments):
+    if not os.path.exists(arguments.output_dir):
+        os.makedirs(arguments.output_dir)
+
+    paired_fpaths = misc.find_paired_fastqs_in_dir(arguments.fastq_dir)
+    log.info('Files to process:')
+    for i, (fpath1, fpath2) in enumerate(paired_fpaths):
+        log.info(f'  {fpath1}')
+        log.info(f'  {fpath2}')
+        if i < len(paired_fpaths)-1:
+            log.info('  -')
+
+    paired_align_fqs_and_tags_fpaths = []
+    namepairidxs = []
+
+    bc_fq_idx, paired_fq_idx = misc.determine_bc_and_paired_fastq_idxs(paired_fpaths, arguments.config)
+    log.info(f'Detected barcodes in read{bc_fq_idx+1} files')
+
+    process_fastqs_func = serial_process_gDNA_fastqs if arguments.threads == 1 else parallel_process_gDNA_fastqs
+    for fpath_tup in paired_fpaths:
+        bc_fq_fpath = fpath_tup[bc_fq_idx]
+        paired_fq_fpath = fpath_tup[paired_fq_idx]
+        sans_bc_fq_fname = f'sans_bc_{misc.file_prefix_from_fpath(bc_fq_fpath)}.fq'
+        sans_bc_fq_fpath = os.path.join(arguments.output_dir, sans_bc_fq_fname)
+        sans_bc_paired_fq_fname = f'sans_paired_{misc.file_prefix_from_fpath(paired_fq_fpath)}.fq'
+        sans_bc_paired_fq_fpath = os.path.join(arguments.output_dir, sans_bc_paired_fq_fname)
+        tags_fname = f'rec_names_and_tags_{misc.file_prefix_from_fpath(bc_fq_fpath)}.txt'
+        namepairidx_fname = f'namepairidx_{misc.file_prefix_from_fpath(bc_fq_fpath)}.pkl'
+        tags_fpath = os.path.join(arguments.output_dir, tags_fname)
+        if bc_fq_idx == 0:
+            paired_align_fqs_and_tags_fpaths.append((sans_bc_fq_fpath, sans_bc_paired_fq_fpath, tags_fpath))
+        else:
+            paired_align_fqs_and_tags_fpaths.append((sans_bc_paired_fq_fpath, sans_bc_fq_fpath, tags_fpath))
+
+        log.info('Processing files:')
+        log.info(f'  barcode fastq: {bc_fq_fpath}')
+        log.info(f'  paired fastq:  {paired_fq_fpath}')
+        log.info(f'  sans-bc fastq: {sans_bc_fq_fpath}')
+        log.info(f'  sans-bc fastq: {sans_bc_paired_fq_fpath}')
+        log.info(f'  tags file:     {tags_fpath}')
+
+        namepairidx = misc.get_namepair_index(bc_fq_fpath, paired_fq_fpath)
+        namepairidxs.append(namepairidx)
+        with open(namepairidx_fname, "wb") as pkl:
+            pickle.dump(namepairidx, pkl)
+
+        if all(os.path.exists(fpath) for fpath in [sans_bc_fq_fpath, sans_bc_paired_fq_fpath, tags_fpath]):
+            log.info('Barcode output found. Skipping barcode detection')
+        else:
+            process_fastqs_func(
+                    arguments,
+                    bc_fq_fpath,
+                    paired_fq_fpath,
+                    sans_bc_fq_fpath,
+                    sans_bc_paired_fq_fpath,
+                    tags_fpath)
+
+    return paired_align_fqs_and_tags_fpaths, namepairidxs
 
 def process_gDNA_fastqs(arguments):
     """
@@ -40,86 +100,50 @@ def process_gDNA_fastqs(arguments):
 
     if not os.path.exists(arguments.output_dir):
         os.makedirs(arguments.output_dir)
-
-    paired_fpaths = misc.find_paired_fastqs_in_dir(arguments.fastq_dir)
-    log.info('Files to process:')
-    for i, (fpath1, fpath2) in enumerate(paired_fpaths):
-        log.info(f'  {fpath1}')
-        log.info(f'  {fpath2}')
-        if i < len(paired_fpaths)-1:
-            log.info('  -')
-
     # find barcodes, write to file, remove from reads before mapping
     # map reads
     # Add barcodes etc to bam file
     # Sort, index
     if completed < 1:
-        bc_fq_idx, paired_fq_idx = misc.determine_bc_and_paired_fastq_idxs(paired_fpaths, arguments.config)
-        log.info(f'Detected barcodes in read{bc_fq_idx+1} files')
         log.info('Writing output to:')
         log.info(f'  {star_w_bc_fpath}')
     
-        paired_align_fqs_and_tags_fpaths = []
-        namepairidxs = []
-        process_fastqs_func = serial_process_gDNA_fastqs if arguments.threads == 1 else parallel_process_gDNA_fastqs
-        for fpath_tup in paired_fpaths:
-            bc_fq_fpath = fpath_tup[bc_fq_idx]
-            paired_fq_fpath = fpath_tup[paired_fq_idx]
-            sans_bc_fq_fname = f'sans_bc_{misc.file_prefix_from_fpath(bc_fq_fpath)}.fq'
-            sans_bc_fq_fpath = os.path.join(arguments.output_dir, sans_bc_fq_fname)
-            sans_bc_paired_fq_fname = f'sans_paired_{misc.file_prefix_from_fpath(paired_fq_fpath)}.fq'
-            sans_bc_paired_fq_fpath = os.path.join(arguments.output_dir, sans_bc_paired_fq_fname)
-            tags_fname = f'rec_names_and_tags_{misc.file_prefix_from_fpath(bc_fq_fpath)}.txt'
-            tags_fpath = os.path.join(arguments.output_dir, tags_fname)
-            if bc_fq_idx == 0:
-                paired_align_fqs_and_tags_fpaths.append((sans_bc_fq_fpath, sans_bc_paired_fq_fpath, tags_fpath))
-            else:
-                paired_align_fqs_and_tags_fpaths.append((sans_bc_paired_fq_fpath, sans_bc_fq_fpath, tags_fpath))
+        if not arguments.star_output_path:
+            paired_align_fqs_and_tags_fpaths, namepairidxs = preprocess_gDNA_fastqs(arguments)
 
-            log.info('Processing files:')
-            log.info(f'  barcode fastq: {bc_fq_fpath}')
-            log.info(f'  paired fastq:  {paired_fq_fpath}')
-            log.info(f'  sans-bc fastq: {sans_bc_fq_fpath}')
-            log.info(f'  sans-bc fastq: {sans_bc_paired_fq_fpath}')
-            log.info(f'  tags file:     {tags_fpath}')
+            log.info(f'Running STAR alignment...')
+            star_out_dirs = set()
+            star_bam_and_tags_fpaths = []
+            for R1_fpath, R2_fpath, tags_fpath in paired_align_fqs_and_tags_fpaths:
+                log.info(f'  {R1_fpath}')
+                log.info(f'  {R2_fpath}')
+                if R1_fpath != paired_align_fqs_and_tags_fpaths[-1][0]:
+                    log.info('  -')
+                star_out_dir, star_out_fpath = run_STAR_gDNA(arguments, R1_fpath, R2_fpath)
+                star_out_dirs.add(star_out_dir)
+                star_bam_and_tags_fpaths.append((star_out_fpath, tags_fpath))
+        else:
+            log.info(f'Using STAR results from {arguments.star_output_path}')
+            tag_fpaths = glob(os.path.join(arguments.fastq_dir, "rec_names_and_tags_*.txt"))
+            namepairidx_fpaths = glob(os.path.join(arguments.fastq_dir, "rec_names_and_tags_*.pkl"))
 
-            namepairidxs.append(misc.get_namepair_index(bc_fq_fpath, paired_fq_fpath))
-
-            if all(os.path.exists(fpath) for fpath in [sans_bc_fq_fpath, sans_bc_paired_fq_fpath, tags_fpath]):
-                log.info('Barcode output found. Skipping barcode detection')
-            else:
-                process_fastqs_func(
-                        arguments, 
-                        bc_fq_fpath, 
-                        paired_fq_fpath, 
-                        sans_bc_fq_fpath,
-                        sans_bc_paired_fq_fpath, 
-                        tags_fpath)
-
-        log.info(f'Running STAR alignment...')
-        star_out_dirs = set()
-        star_bam_and_tags_fpaths = []
-        for R1_fpath, R2_fpath, tags_fpath in paired_align_fqs_and_tags_fpaths:
-            log.info(f'  {R1_fpath}')
-            log.info(f'  {R2_fpath}')
-            if R1_fpath != paired_align_fqs_and_tags_fpaths[-1][0]:
-                log.info('  -')
-            star_out_dir, star_out_fpath = run_STAR_gDNA(arguments, R1_fpath, R2_fpath)
-            star_out_dirs.add(star_out_dir)
-            star_bam_and_tags_fpaths.append((star_out_fpath, tags_fpath))
+            star_bam_and_tags_fpaths = [(bam, fpath) for bam, fpath in zip(arguments.star_output_path, sorted(fpaths))]
+            namepairidxs = [pickle.load(open(fpath, "rb")) for fpath in sorted(namepairidx_fpaths)]
 
         log.info('Adding barcode tags to mapped reads...')
         template_bam_fpath = star_bam_and_tags_fpaths[0][0]
         with pysam.AlignmentFile(star_w_bc_fpath, 'wb', template=pysam.AlignmentFile(template_bam_fpath)) as bam_out:
             for (star_out_fpath, tags_fpath), namepairidx in zip(star_bam_and_tags_fpaths, namepairidxs):
-                if arguments.threads == 1:
+                if arguments.threads == 1 and not arguments.star_output_path:
                     readsiter = iter(serial_gDNA_add_tags_to_reads(tags_fpath, star_out_fpath))
                 else:
                     readsiter = iter(parallel_gDNA_add_tags_to_reads(tags_fpath, star_out_fpath, namepairidx, arguments.threads))
                 for read in readsiter:
                     bam_out.write(read)
-        for fpath in (sans_bc_fq_fpath, sans_bc_paired_fq_fpath, tags_fpath):
-            os.remove(fpath)
+
+        for fpaths in paired_align_fqs_and_tags_fpaths:
+            for fpath in fpaths:
+                os.remove(fpath)
         for star_out_dir in star_out_dirs:
             shutil.rmtree(star_out_dir)  # clean up intermediate STAR files
     

--- a/SDRranger/main.py
+++ b/SDRranger/main.py
@@ -3,7 +3,8 @@ SDRranger: Processing Genomic-Transcriptomic TAP-Seq data.
 
 Usage:
   SDRranger count_RNA        <fastq_dir> (--STAR-ref-dir=<> | --STAR-output=<>...) --config=<> [--output-dir=<>] [--threads=<>] [-v | -vv | -vvv]
-  SDRranger count_gDNA       <fastq_dir> --STAR-ref-dir=<> --config=<> [--output-dir=<>] [--threads=<>] [-v | -vv | -vvv]
+  SDRranger count_gDNA       <fastq_dir> (--STAR-ref-dir=<> | --STAR-output=<>...) --config=<> [--output-dir=<>] [--threads=<>] [-v | -vv | -vvv]
+  SDRranger preprocess_gDNA  <fastq_dir> --config=<> [--output-dir=<>] [--threads=<>] [-v | -vv | -vvv]
   SDRranger count_matrix       <SDR_bam_file> --output-dir=<> [--threads=<>] [-v | -vv | -vvv]
 
 Options:
@@ -19,9 +20,10 @@ Options:
   --version     Show version.
 
 Commands:
-  count_gDNA    Process and count Genomic gDNA files
-  count_RNA     Process and count Transcriptomic RNA files
-  count_matrix  Build a count matrix (or matrices) from an existing bam file
+  preprocess_gDNA  Preprocess Genomic gDNA files such that STAR can be run on the output.
+  count_gDNA       Process and count Genomic gDNA files
+  count_RNA        Process and count Transcriptomic RNA files
+  count_matrix     Build a count matrix (or matrices) from an existing bam file
 """
 import logging
 import os
@@ -29,7 +31,7 @@ from docopt import docopt
 from .__init__ import __version__
 from .config import CommandLineArguments
 from .RNAcount import process_RNA_fastqs
-from .gDNAcount import process_gDNA_fastqs 
+from .gDNAcount import process_gDNA_fastqs, preprocess_gDNA_fastqs
 from .count_matrix import build_count_matrices_from_bam
 
 def main(**kwargs):
@@ -47,6 +49,7 @@ def main(**kwargs):
     commands = {
         'count_RNA': process_RNA_fastqs,
         'count_gDNA': process_gDNA_fastqs,
+        'preprocess_gDNA': preprocess_gDNA_fastqs,
         'count_matrix': build_count_matrices_from_bam,
     }
 

--- a/SDRranger/misc.py
+++ b/SDRranger/misc.py
@@ -88,6 +88,23 @@ def names_pair(s1, s2):
     """
     return all(c1 == c2 or set([c1, c2]) == set('12') for c1, c2 in zip(s1, s2))
 
+def namepair_differences(r1, r2):
+    return [i for i, (c1, c2) in enumerate(zip(r1, r2)) if c1 != c2]
+
+def make_paired_name(readname, idx):
+    name = ""
+    lastidx = 0
+    for i in idx:
+        name += readname[lastidx:i]
+        lastidx = i + 1
+    name += readname[lastidx:]
+    return name
+
+def get_namepair_index(R1_fpath, R2_fpath):
+    r1 = next(SeqIO.parse(gzip_friendly_open(R1_fpath), 'fastq'))
+    r2 = next(SeqIO.parse(gzip_friendly_open(R2_fpath), 'fastq'))
+    return namepair_differences(r1.id, r2.id)
+
 
 def file_prefix_from_fpath(fpath):
     """Strip away directories and extentions from file path"""
@@ -194,7 +211,7 @@ def write_matrix(M, bcs, features, out_dir):
     with gzip.open(cols_fpath, 'wt') as out:
         out.write('\n'.join([f'{gx}\t{gn}\tGene Expression' for gx, gn in features]))
 
-def sort_and_index_readname_bam(input_bam_fpath, output_bam_fpath, threads=1):
+def sort_and_index_readname_bam(input_bam_fpath, output_bam_fpath, namepairidx, threads=1):
     pysam.sort("-N", "-@", str(threads), "-o", output_bam_fpath, input_bam_fpath)
     with pysam.AlignmentFile(output_bam_fpath, "r", threads=threads) as bam:
         i_readnames = []
@@ -205,23 +222,26 @@ def sort_and_index_readname_bam(input_bam_fpath, output_bam_fpath, threads=1):
         lastreadoffset = offset
         for read in bam.fetch(until_eof=True):
             block = offset >> 16
+            readname = make_paired_name(read.query_name, namepairidx)
             if block > lastblock:
-                i_readnames.append(read.query_name)
-                i_offsets.append(offset if read.query_name != lastreadname else lastreadoffset)
+                i_readnames.append(readname)
+                i_offsets.append(offset if readname != lastreadname else lastreadoffset)
                 lastblock = block
-            if read.query_name != lastreadname:
-                lastreadname = read.query_name
+            if readname != lastreadname:
+                lastreadname = readname
                 lastreadoffset = offset
             offset = bam.tell()
 
-    return i_readnames, i_offsets
+    return i_readnames, i_offsets, namepairidx
 
 def get_bam_read_by_name(name, bam, index, threads=1):
-    i_readnames, i_offsets = index
-    idx = bisect(i_readnames, name) - 1
+    i_readnames, i_offsets, namepairidx = index
+    name = make_paired_name(name, namepairidx)
+
+    idx = bisect(i_readnames, make_paired_name(name, namepairidx)) - 1
     needclose = False
     if not isinstance(bam, pysam.AlignmentFile):
-        bam = pysam.AlignmentFile(bam_fpath, "r", threads=threads)
+        bam = pysam.AlignmentFile(bam, "r", threads=threads)
         needclose = True
     bam.seek(i_offsets[idx])
     startblock = None
@@ -229,7 +249,7 @@ def get_bam_read_by_name(name, bam, index, threads=1):
     for bread in bam.fetch(until_eof=True):
         if startblock is None:
             startblock = bam.tell() >> 16
-        if names_pair(bread.query_name, name):
+        if make_paired_name(bread.query_name, namepairidx) == name:
             haveread = True
             yield bread
         elif haveread or bam.tell() >> 16 > startblock:


### PR DESCRIPTION
This PR enables running multithreaded STAR by implementing a custom BAM indexing scheme to look up reads by name. The BAM file is first sorted by name, then a custom in-memory index is constructed: The name of the first read in a block along with its offset is stored. The block for a given read name can then be found by a binary search of the index.

Sorting a BAM file by name requires samtools >= 1.19. The latest pysam wraps samtools 1.18. I have opened a [pull request](https://github.com/pysam-developers/pysam/pull/1289) with pysam, in the meantime my pysam fork can be used.